### PR TITLE
fix: fixed game reset

### DIFF
--- a/FlyRight/Base.lproj/LaunchScreen.storyboard
+++ b/FlyRight/Base.lproj/LaunchScreen.storyboard
@@ -1,12 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -18,14 +14,14 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="52" y="374.66266866566718"/>
+            <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
 </document>

--- a/FlyRight/Base.lproj/Main.storyboard
+++ b/FlyRight/Base.lproj/Main.storyboard
@@ -95,7 +95,7 @@
                                         <rect key="frame" x="101" y="0.0" width="69" height="40"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" Score:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qzm-Rp-FT8">
-                                                <rect key="frame" x="0.5" y="0.0" width="67.5" height="20"/>
+                                                <rect key="frame" x="1" y="0.0" width="67.5" height="20"/>
                                                 <fontDescription key="fontDescription" name="GillSans-UltraBold" family="Gill Sans" pointSize="16"/>
                                                 <color key="textColor" red="0.90588235294117647" green="0.83529411764705885" blue="0.83529411764705885" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>

--- a/FlyRight/GameOverViewController.swift
+++ b/FlyRight/GameOverViewController.swift
@@ -12,6 +12,7 @@ import AVFoundation
 
 class GameOverViewController: UIViewController {
 
+    weak var gVC: GameViewController!
     var scene: GameOverScene!
     
     // MARK: View Controller Functions
@@ -22,7 +23,11 @@ class GameOverViewController: UIViewController {
 
     @IBAction func restartGame(_ sender: Any) {
         self.removeAnimate()
-        gameViewController.refreshGame()
+        if self.view.isDescendant(of: gVC.view) {
+            self.view.removeFromSuperview()
+        }
+        self.removeFromParentViewController()
+        gVC.refreshGame()
     }
     
     override var shouldAutorotate: Bool {

--- a/FlyRight/GameScene.swift
+++ b/FlyRight/GameScene.swift
@@ -43,7 +43,7 @@ extension UIImage {
 
 class GameScene: SKScene {
 
-    var gameViewController = GameViewController()
+    var gameViewController: GameViewController?
     
     // MARK: Properties
 

--- a/FlyRight/GameViewController.swift
+++ b/FlyRight/GameViewController.swift
@@ -11,8 +11,6 @@ import UIKit
 import SpriteKit
 import AVFoundation
 
-var gameViewController: GameViewController = GameViewController()
-
 class GameViewController: UIViewController {
 
     // This outlet counts number of turns to factor into the score.
@@ -32,7 +30,7 @@ class GameViewController: UIViewController {
     
     //This method will update any labels with appropriate values.
     func updateLabels() {
-        tilesLabel.text = String(format: "%ld", Level.tiles)
+        tilesLabel.text = String(format: "%ld", scene.level.tileCount)
         turnLabel.text = String(format: "%ld", turns)
         //here the genScore() func is dynamically called to continually update the displayed total score
         scoreLabel.text = String(format: "%ld", genScore())
@@ -40,7 +38,7 @@ class GameViewController: UIViewController {
 
     // This func will correctly relate the turns and tiles to generate a score.
     func genScore() -> Int {
-        return (Level.tiles * 4 / 10) * (turns * 12 / 10) * 10
+        return (scene.level.tileCount * 4 / 10) * (turns * 12 / 10) * 10
     }
 
     // The outlet to make a turn.
@@ -51,13 +49,14 @@ class GameViewController: UIViewController {
 
     //End the game and transition over the GameOverViewController.
     func gameOver() {
-
         let gameOverVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "gameOverID") as! GameOverViewController
-        self.addChildViewController(gameOverVC)
+        gameOverVC.gVC = self
+        gameOverVC.view.tag = 100
         gameOverVC.view.frame = self.view.frame
+        
+        self.addChildViewController(gameOverVC)
         self.view.addSubview(gameOverVC.view)
         gameOverVC.didMove(toParentViewController: self)
-
     }
     
     // Reset all labels to 0 when restarting game.
@@ -131,9 +130,6 @@ class GameViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //set global variable to proper object
-        gameViewController = self
-        
         // Configure the view.
         print("Going to vdl")
         let skView = self.view as! SKView
@@ -173,6 +169,7 @@ class GameViewController: UIViewController {
         // Fill up the level with new spaces, and create sprites for them.
         let newSpace = level.shuffle()
         scene.addSprites(for: newSpace)
+        print("here")
         resetLabels()
     }
 

--- a/FlyRight/GameViewController.swift
+++ b/FlyRight/GameViewController.swift
@@ -169,7 +169,6 @@ class GameViewController: UIViewController {
         // Fill up the level with new spaces, and create sprites for them.
         let newSpace = level.shuffle()
         scene.addSprites(for: newSpace)
-        print("here")
         resetLabels()
     }
 

--- a/FlyRight/Level.swift
+++ b/FlyRight/Level.swift
@@ -18,19 +18,20 @@ var timesRun = 0
 class Level {
 
     // The scene draws the tiles and space sprites, and handles actions (swipes for CC).
-    var scene: GameScene!
+    weak var scene: GameScene!
 
     // Reference to Space from Level.
     var shipRef: Space?
 
     // This var will be the running static score of how many tiles the spaceShip has flown over.
-    static var tiles: Int = 0
+    // Really you shouldn't have two variables with the same name
+    var tileCount: Int = 0
 
     // Variable to access the Space type.
     var space: Space!
 
     // This Bool will trigger the showing of the Game-Over screen.
-    static var isGameOver: Bool = false
+    var isGameOver: Bool = false
 
     // MARK: Properties
 
@@ -43,7 +44,7 @@ class Level {
     var tileCounter = 0
 
     // Variable of viewController to call showGameOver() (moved to gameOver).
-    var viewController: GameViewController!
+    weak var viewController: GameViewController!
     
     // MARK: Initialization
 
@@ -55,7 +56,7 @@ class Level {
         // turn is also an array describing the columns in that row. If a column
         // is 1, it means there is a tile at that location, 0 means there is not.
 
-        self.scene? = self.viewController.scene
+        self.scene? = scene
 
         guard let tilesArray = dictionary["tiles"] as? [[Int]] else { return }
 
@@ -103,18 +104,17 @@ class Level {
             }
         }
         //make xpos ypos
-        var spaceShip: Space
-        spaceShip = shipRef!
-        if (timesRun > 0 && !Level.isGameOver) {
-            spaceShip.move()
-            Level.tiles += 1
+
+        if (timesRun > 0 && !isGameOver) {
+            shipRef!.move()
+            tileCount += 1
             self.viewController.updateLabels()
             if !(detectAsteroid(row: ((getShipRef()?.getRow()))!, column: (getShipRef()?.getColumn())!)) {
                 addAsteroid()
             }
         }
         timesRun += 1
-        set.insert(spaceShip)
+        set.insert(shipRef!)
         return set
     }
 
@@ -129,17 +129,17 @@ class Level {
     //Checks the Dictionary to see if an Asteroid is at the given index of the spaceShip and triggers "Game Over" if so.
     func detectAsteroid(row: Int, column: Int) -> Bool {
         if ((column < NumColumns - NumColumns) || (column >= NumColumns)) {
-            Level.isGameOver = true
+            isGameOver = true
             self.viewController.gameOver()
             return true
         }
         if ((row < NumRows - NumRows) || (row >= NumRows)) {
-            Level.isGameOver = true
+            isGameOver = true
             self.viewController.gameOver()
             return true
         }
         if (tiles[column, row] != nil) {
-            Level.isGameOver = true
+            isGameOver = true
             self.viewController.gameOver()
             return true
         }
@@ -156,8 +156,8 @@ class Level {
 
     // UPDATE THIS JACOB
     // This method will recalculate the score at the restart of the game.
-    static func calculateScore() {
-        tiles = 0
+    func calculateScore() {
+        tileCount = 0
     }
 
     // MARK: Query the level


### PR DESCRIPTION
I fixed your big bug. Your main issue is that you were using static fields from Level to control the logic of the game, so even when you make a new Level object, the static fields remain what you changed them to previously. Specifically, you change Level.isGameOver to true when the game ends, but never change it back. This doesn't make a whole lot of sense in general because a Level's determination of a game being over should be specific to its object and thus shouldn't be a static field. I changed it to a non-static field across the board.

I also added weak references to the circular references you've got all over the app. I might have missed a few, maybe read up on those when you can.

There's still a lingering bug when you start the game where the ship starts one space above where you'd expect, but you can figure that out. Try to draw out your objects more so you can get a better idea about what fields are controlling what other objects and maybe that will help you conform to OOP and MVC.